### PR TITLE
upgrade golang base image to 1.18.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: devopsworks/golang-upx
+          images: zuzur/golang-upx
           tags: |
             type=raw,value=latest
             type=ref,event=tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.18.1
 
 ARG upx_version=3.96
 ARG GOPROXY


### PR DESCRIPTION
i needed a 1.18.1 image to validate my builds against recent golang versions